### PR TITLE
Implement bounce angles for Pong collisions

### DIFF
--- a/frontend/game_websocket/pong_websocket.ts
+++ b/frontend/game_websocket/pong_websocket.ts
@@ -1,4 +1,5 @@
 // all numbers are in % of screen height, if the aspect ratio is fixed to 2, this means that the x axis goes to 200%
+const MAX_BOUNCE_ANGLE = 75 * Math.PI / 180;
 
 enum userInput {
 	unknown = 0,
@@ -54,6 +55,24 @@ class Ball {
         this.radius = radius;
         this.speedX = speed;
         this.speedY = speed;
+    }
+
+    checkCollision(paddle: Paddle): void
+    {
+        if (this.y + this.radius >= paddle.y && this.y - this.radius <= paddle.y + paddle.height)
+        {
+            if ((this.speedX < 0 && paddle.x < 50 && this.x - this.radius <= paddle.x + paddle.width) ||
+                (this.speedX > 0 && paddle.x > 50 && this.x + this.radius >= paddle.x))
+            {
+                const relativeIntersectY = this.y - (paddle.y + paddle.height / 2);
+                const normalized = relativeIntersectY / (paddle.height / 2);
+                const angle = normalized * MAX_BOUNCE_ANGLE;
+                const speed = Math.hypot(this.speedX, this.speedY);
+                const direction = paddle.x < 50 ? 1 : -1;
+                this.speedX = speed * Math.cos(angle) * direction;
+                this.speedY = speed * Math.sin(angle);
+            }
+        }
     }
 
 

--- a/frontend/pong.ts
+++ b/frontend/pong.ts
@@ -1,4 +1,5 @@
 // all numbers are in % of screen height, if the aspect ratio is fixed to 2, this means that the x axis goes to 200%
+const MAX_BOUNCE_ANGLE = 75 * Math.PI / 180;
 
 class Paddle {
     x: number;
@@ -67,31 +68,20 @@ class Ball {
 
     checkCollision(paddle: Paddle): void
     {
-		// we may have to add collision detection with the top and bottom of the paddle
-
-		// y direction
-		if (this.y >= paddle.y && this.y <= paddle.y + paddle.height)
-		{
-			// x direction left paddle
-			if (this.speedX < 0 && paddle.x < 50 && this.x - this.radius <= paddle.x + paddle.width)
-			{
-				this.speedX *= -1;
-			}
-			// x direction right paddle
-			else if (this.speedX > 0 && paddle.x > 50 && this.x + this.radius >= paddle.x)
-			{
-				this.speedX *= -1;
-			}
-		}
-
-		// with the code below, the ball was sticking to the paddle sometimes
-		/*
-        if ( this.x - this.radius <= paddle.x + paddle.width && this.x + this.radius >= paddle.x &&
-            this.y >= paddle.y && this.y <= paddle.y + paddle.height )
+        if (this.y + this.radius >= paddle.y && this.y - this.radius <= paddle.y + paddle.height)
         {
-            this.speedX *= -1;
+            if ((this.speedX < 0 && paddle.x < 50 && this.x - this.radius <= paddle.x + paddle.width) ||
+                (this.speedX > 0 && paddle.x > 50 && this.x + this.radius >= paddle.x))
+            {
+                const relativeIntersectY = this.y - (paddle.y + paddle.height / 2);
+                const normalized = relativeIntersectY / (paddle.height / 2);
+                const angle = normalized * MAX_BOUNCE_ANGLE;
+                const speed = Math.hypot(this.speedX, this.speedY);
+                const direction = paddle.x < 50 ? 1 : -1;
+                this.speedX = speed * Math.cos(angle) * direction;
+                this.speedY = speed * Math.sin(angle);
+            }
         }
-			*/
     }
 
     draw(ctx: CanvasRenderingContext2D, canvasHeight: number): void


### PR DESCRIPTION
## Summary
- modify the front-end Pong collision logic to calculate a bounce angle
- add the same function in the WebSocket Pong client

## Testing
- `npx tsc -p frontend` *(fails: Cannot redeclare block-scoped variable)*

------
https://chatgpt.com/codex/tasks/task_e_6841a8bd7d388332a879858fb11e0f85