### PR TITLE
Improve paddle collision angles

### DIFF
--- a/backend/pong_server.js
+++ b/backend/pong_server.js
@@ -76,16 +76,31 @@ class Ball {
         }
     }
     checkCollision(paddle) {
-        // we may have to add collision detection with the top and bottom of the paddle
-        // y direction
-        if (this.y >= paddle.y && this.y <= paddle.y + paddle.height) {
-            // x direction left paddle
-            if (this.speedX < 0 && paddle.x < 50 && this.x - this.radius <= paddle.x + paddle.width) {
-                this.speedX *= -1;
+        // side collisions (left/right of the paddle)
+        if (this.y + this.radius >= paddle.y && this.y - this.radius <= paddle.y + paddle.height) {
+            const speed = Math.sqrt(this.speedX * this.speedX + this.speedY * this.speedY);
+            // collision with left paddle
+            if (this.speedX < 0 && this.x - this.radius <= paddle.x + paddle.width && this.x > paddle.x) {
+                const offset = (this.y - (paddle.y + paddle.height / 2)) / (paddle.height / 2);
+                const angle = offset * Math.PI / 3; // limit bounce angle
+                this.speedX = speed * Math.cos(angle);
+                this.speedY = speed * Math.sin(angle);
             }
-            // x direction right paddle
-            else if (this.speedX > 0 && paddle.x > 50 && this.x + this.radius >= paddle.x) {
-                this.speedX *= -1;
+            // collision with right paddle
+            else if (this.speedX > 0 && this.x + this.radius >= paddle.x && this.x < paddle.x + paddle.width) {
+                const offset = (this.y - (paddle.y + paddle.height / 2)) / (paddle.height / 2);
+                const angle = offset * Math.PI / 3;
+                this.speedX = -speed * Math.cos(angle);
+                this.speedY = speed * Math.sin(angle);
+            }
+        }
+        // collisions from top or bottom of the paddle
+        if (this.x + this.radius >= paddle.x && this.x - this.radius <= paddle.x + paddle.width) {
+            if (this.speedY > 0 && this.y - this.radius <= paddle.y && this.y > paddle.y) {
+                this.speedY *= -1;
+            }
+            else if (this.speedY < 0 && this.y + this.radius >= paddle.y + paddle.height && this.y < paddle.y + paddle.height) {
+                this.speedY *= -1;
             }
         }
     }

--- a/backend/pong_server.ts
+++ b/backend/pong_server.ts
@@ -101,22 +101,41 @@ class Ball {
 
     checkCollision(paddle: Paddle): void
     {
-		// we may have to add collision detection with the top and bottom of the paddle
+        // side collisions (left/right of the paddle)
+        if (this.y + this.radius >= paddle.y && this.y - this.radius <= paddle.y + paddle.height)
+        {
+            const speed = Math.sqrt(this.speedX * this.speedX + this.speedY * this.speedY);
 
-		// y direction
-		if (this.y >= paddle.y && this.y <= paddle.y + paddle.height)
-		{
-			// x direction left paddle
-			if (this.speedX < 0 && paddle.x < 50 && this.x - this.radius <= paddle.x + paddle.width)
-			{
-				this.speedX *= -1;
-			}
-			// x direction right paddle
-			else if (this.speedX > 0 && paddle.x > 50 && this.x + this.radius >= paddle.x)
-			{
-				this.speedX *= -1;
-			}
-		}
+            // collision with left paddle
+            if (this.speedX < 0 && this.x - this.radius <= paddle.x + paddle.width && this.x > paddle.x)
+            {
+                const offset = (this.y - (paddle.y + paddle.height / 2)) / (paddle.height / 2);
+                const angle = offset * Math.PI / 3; // limit bounce angle
+                this.speedX = speed * Math.cos(angle);
+                this.speedY = speed * Math.sin(angle);
+            }
+            // collision with right paddle
+            else if (this.speedX > 0 && this.x + this.radius >= paddle.x && this.x < paddle.x + paddle.width)
+            {
+                const offset = (this.y - (paddle.y + paddle.height / 2)) / (paddle.height / 2);
+                const angle = offset * Math.PI / 3;
+                this.speedX = -speed * Math.cos(angle);
+                this.speedY = speed * Math.sin(angle);
+            }
+        }
+
+        // collisions from top or bottom of the paddle
+        if (this.x + this.radius >= paddle.x && this.x - this.radius <= paddle.x + paddle.width)
+        {
+            if (this.speedY > 0 && this.y - this.radius <= paddle.y && this.y > paddle.y)
+            {
+                this.speedY *= -1;
+            }
+            else if (this.speedY < 0 && this.y + this.radius >= paddle.y + paddle.height && this.y < paddle.y + paddle.height)
+            {
+                this.speedY *= -1;
+            }
+        }
     }
 
 	getPosition(): { x: number, y: number } {

--- a/frontend/pong.js
+++ b/frontend/pong.js
@@ -49,12 +49,31 @@ class Ball {
         }
     }
     checkCollision(paddle) {
-        if (this.y >= paddle.y && this.y <= paddle.y + paddle.height) {
-            if (this.speedX < 0 && paddle.x < 50 && this.x - this.radius <= paddle.x + paddle.width) {
-                this.speedX *= -1;
+        // side collisions (left/right of the paddle)
+        if (this.y + this.radius >= paddle.y && this.y - this.radius <= paddle.y + paddle.height) {
+            const speed = Math.sqrt(this.speedX * this.speedX + this.speedY * this.speedY);
+            // collision with left paddle
+            if (this.speedX < 0 && this.x - this.radius <= paddle.x + paddle.width && this.x > paddle.x) {
+                const offset = (this.y - (paddle.y + paddle.height / 2)) / (paddle.height / 2);
+                const angle = offset * Math.PI / 3;
+                this.speedX = speed * Math.cos(angle);
+                this.speedY = speed * Math.sin(angle);
             }
-            else if (this.speedX > 0 && paddle.x > 50 && this.x + this.radius >= paddle.x) {
-                this.speedX *= -1;
+            // collision with right paddle
+            else if (this.speedX > 0 && this.x + this.radius >= paddle.x && this.x < paddle.x + paddle.width) {
+                const offset = (this.y - (paddle.y + paddle.height / 2)) / (paddle.height / 2);
+                const angle = offset * Math.PI / 3;
+                this.speedX = -speed * Math.cos(angle);
+                this.speedY = speed * Math.sin(angle);
+            }
+        }
+        // collisions from top or bottom of the paddle
+        if (this.x + this.radius >= paddle.x && this.x - this.radius <= paddle.x + paddle.width) {
+            if (this.speedY > 0 && this.y - this.radius <= paddle.y && this.y > paddle.y) {
+                this.speedY *= -1;
+            }
+            else if (this.speedY < 0 && this.y + this.radius >= paddle.y + paddle.height && this.y < paddle.y + paddle.height) {
+                this.speedY *= -1;
             }
         }
     }

--- a/frontend/pong.ts
+++ b/frontend/pong.ts
@@ -67,31 +67,41 @@ class Ball {
 
     checkCollision(paddle: Paddle): void
     {
-		// we may have to add collision detection with the top and bottom of the paddle
-
-		// y direction
-		if (this.y >= paddle.y && this.y <= paddle.y + paddle.height)
-		{
-			// x direction left paddle
-			if (this.speedX < 0 && paddle.x < 50 && this.x - this.radius <= paddle.x + paddle.width)
-			{
-				this.speedX *= -1;
-			}
-			// x direction right paddle
-			else if (this.speedX > 0 && paddle.x > 50 && this.x + this.radius >= paddle.x)
-			{
-				this.speedX *= -1;
-			}
-		}
-
-		// with the code below, the ball was sticking to the paddle sometimes
-		/*
-        if ( this.x - this.radius <= paddle.x + paddle.width && this.x + this.radius >= paddle.x &&
-            this.y >= paddle.y && this.y <= paddle.y + paddle.height )
+        // side collisions (left/right of the paddle)
+        if (this.y + this.radius >= paddle.y && this.y - this.radius <= paddle.y + paddle.height)
         {
-            this.speedX *= -1;
+            const speed = Math.sqrt(this.speedX * this.speedX + this.speedY * this.speedY);
+
+            // collision with left paddle
+            if (this.speedX < 0 && this.x - this.radius <= paddle.x + paddle.width && this.x > paddle.x)
+            {
+                const offset = (this.y - (paddle.y + paddle.height / 2)) / (paddle.height / 2);
+                const angle = offset * Math.PI / 3;
+                this.speedX = speed * Math.cos(angle);
+                this.speedY = speed * Math.sin(angle);
+            }
+            // collision with right paddle
+            else if (this.speedX > 0 && this.x + this.radius >= paddle.x && this.x < paddle.x + paddle.width)
+            {
+                const offset = (this.y - (paddle.y + paddle.height / 2)) / (paddle.height / 2);
+                const angle = offset * Math.PI / 3;
+                this.speedX = -speed * Math.cos(angle);
+                this.speedY = speed * Math.sin(angle);
+            }
         }
-			*/
+
+        // collisions from top or bottom of the paddle
+        if (this.x + this.radius >= paddle.x && this.x - this.radius <= paddle.x + paddle.width)
+        {
+            if (this.speedY > 0 && this.y - this.radius <= paddle.y && this.y > paddle.y)
+            {
+                this.speedY *= -1;
+            }
+            else if (this.speedY < 0 && this.y + this.radius >= paddle.y + paddle.height && this.y < paddle.y + paddle.height)
+            {
+                this.speedY *= -1;
+            }
+        }
     }
 
     draw(ctx: CanvasRenderingContext2D, canvasHeight: number): void


### PR DESCRIPTION
## Summary
- vary bounce angle by calculating hit position on paddle
- bounce when hitting paddle tops and bottoms
- update frontend game logic to match

## Testing
- `node -e "const {game}=require('./backend/pong_server.js'); console.log('ball',game.ball.x,game.ball.y); game.ball.x=2; game.ball.y=50; game.ball.speedX=-20; game.ball.speedY=0; game.ball.checkCollision(game.paddleLeft); console.log(game.ball.speedX, game.ball.speedY);"`
- `node - <<'NODE'
const {game}=require('./backend/pong_server.js');
const paddle=game.paddleRight;
paddle.y=40;
const ball=game.ball;
ball.x=paddle.x-1;
ball.y=paddle.y + paddle.height/2 + 5;
ball.speedX=20;
ball.speedY=0;
ball.checkCollision(paddle);
console.log('after',ball.speedX.toFixed(2),ball.speedY.toFixed(2));
NODE`

------
https://chatgpt.com/codex/tasks/task_e_6841b2723928833299d76d3bfec64539